### PR TITLE
fix(cli): load built images locally on any buildx driver

### DIFF
--- a/reflowfy/cli/commands/build.py
+++ b/reflowfy/cli/commands/build.py
@@ -67,11 +67,17 @@ def _build_images(
         )
 
         try:
+            # load=True guarantees the built image (with all tags) is loaded into
+            # the local Docker daemon regardless of the active buildx driver. Without
+            # it, the default "docker" driver happens to load the image but the
+            # "docker-container" driver does not, leaving the subsequent push loop
+            # with no local image to push.
             docker.build(
                 str(build_context),
                 file=str(dockerfile_full),
                 tags=tags,
                 cache=not no_cache,
+                load=True,
                 build_args={"REFLOWFY_BASE_IMAGE": reflowfy_base},
             )
             console.print(f"✅ Built [bold]{', '.join(tags)}[/bold]", style="green")


### PR DESCRIPTION
## Problem

`reflowfy build` calls `docker.build()` with no `load=`/`push=`, then pushes each tag in a **separate loop** afterwards.

On the default **`docker`** buildx driver this happens to work — that driver implicitly loads the built image into the local daemon, so the later `docker.push(tag)` finds it. But on the **`docker-container`** driver (common in CI, or anyone who ran `docker buildx create --use`), `python_on_whales` does **not** load the image into the daemon, so:

- the image is **not saved locally**, and
- the subsequent push loop fails with "image does not exist locally".

Each image is only built once (a tag list becomes `--tag a --tag b` on a single `docker buildx build`), so this was never a literal double-build — the "twice" is the two tags (`:latest` + `:<version>`) each being pushed.

## Fix

Pass `load=True` to `docker.build()`. Now the image — with all its tags — is always loaded into the local Docker daemon regardless of the active buildx driver. Images are kept locally **and** both tags still push to the registry.

## Verification

- Traced the resulting call sequence: one build per image (`load=True`), followed by a push per tag.
- `ruff check`, `black --check`, and `mypy` on the file are clean (the two remaining mypy notes are pre-existing missing-return-annotations on the typer command, present on `main`).